### PR TITLE
Avoid to pollute Globals in Node. Define specially.

### DIFF
--- a/lib/inverted-min.js
+++ b/lib/inverted-min.js
@@ -6,7 +6,7 @@
  Copyright (c) 2013, Phil Mander
  Licensed under the MIT license
 */
-"function"!==typeof define&&(define=require("amdefine")(module));
+"function"!==typeof define&&(var define=require("amdefine")(module););
 define("inverted/Util",function(){var k={isArray:function(a){return Array.isArray?Array.isArray(a):"[object Array]"===Object.prototype.toString.call(a)},inArray:function(a,g){if(g.indexOf)return g.indexOf(a);for(var h=0,f=g.length;h<f;h++)if(g[h]===a)return h;return-1},trim:function(a){return a?a.replace(/^\s+|\s+$/g,""):a},parseProtoReference:function(a){a=a.match(/^(.+?)(\[(.+?)\])?$/);return{protoId:k.trim(a[1]),interfaces:a[3]?k.splitCommaDelimited(a[3]):null}},matchProtoRefString:function(a){return"string"===
 typeof a&&null!==a.match(/^\*[^\*]/)},splitCommaDelimited:function(a){return a?a.split(/\s*,\s*/):[]},warn:function(a){"undefined"!==typeof console&&console.warn&&(a instanceof Error?console.warn(a.message,a):console.warn(a))},createError:function(a){return new k.InvertedError(a)},InvertedError:function(a){this.message=a}};k.InvertedError.prototype=Error.prototype;k.InvertedError.prototype.print=function(){k.warn(this.message)};return k});
 define("inverted/Promise",function(){var k=function(a){this._ctx=a;this._sucesses=[];this._failures=[]};k.prototype.then=function(a,g){"function"===typeof a&&this._sucesses.push(a);"function"===typeof g&&this._failures.push(g)};k.prototype.notifySuccess=function(a){for(var g=0;g<this._sucesses.length;g++)this._sucesses[g].apply(this._ctx,a)};k.prototype.notifyFailure=function(a){for(var g=0;g<this._failures.length;g++)this._failures[g].call(this._ctx,a)};return k});

--- a/lib/inverted.js
+++ b/lib/inverted.js
@@ -7,7 +7,7 @@
  * Licensed under the MIT license
  */
 if (typeof define !== 'function') {
-    define = require('amdefine')(module)
+    var define = require('amdefine')(module);
 }
 /**
  * Misc functions shared throughout the Inverted codebase

--- a/src/package/intro.js
+++ b/src/package/intro.js
@@ -7,5 +7,5 @@
  * Licensed under the MIT license
  */
 if (typeof define !== 'function') {
-    define = require('amdefine')(module)
+    var define = require('amdefine')(module);
 }


### PR DESCRIPTION
Not using the var may create (in node.js it does) a global variable of that name. Then, other modules loaded via node's require or via amdefine's require will not work.

An exception like `amdefine with no module ID cannot be called more than once per file.` will appear, because we will be referring in the next files to this _old_ `define`.
